### PR TITLE
Update README.md till wakatime stat issue is fixed permanently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=seanpm2001&layout=compact)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th
 
-[![Seanpm2001's wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=seanpm2001)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th
+<!--[![Seanpm2001's wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=seanpm2001)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th /-->
 
 Do you want to have these counters on your profile? They are pretty easy to set up. You can go directly to the projects (contains in-depth info)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=seanpm2001&layout=compact)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th
 
-<!--[![Seanpm2001's wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=seanpm2001)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th /-->
+<!--[![Seanpm2001's wakatime stats](https://github-readme-stats.vercel.app/api/wakatime?username=seanpm2001)](https://github.com/anuraghazra/github-readme-stats) - This counter was added on 2021 December 30th !-->
 
 Do you want to have these counters on your profile? They are pretty easy to set up. You can go directly to the projects (contains in-depth info)
 


### PR DESCRIPTION
# Description
As it can be seen in [Readme](https://github.com/seanpm2001/seanpm2001/blob/master/README.md) file. Third github-readme-stats is showing an error and the reason behind it is that either you haven't signed up on https://wakatime.com/ or you are not using wakatime's username in link instead I saw you used GitHub's username but it was clearly mentioned by [@anuraghazara](https://github.com/anuraghazra/github-readme-stats#wakatime-week-stats). 

Fixed #64 

This fix is for the time being till you login or signup for wakatime and put you profile link in `?username=`. Till then it is better not have that on you profile page.